### PR TITLE
mono: fix cert-sync path

### DIFF
--- a/spk/mono/src/installer.sh
+++ b/spk/mono/src/installer.sh
@@ -23,7 +23,7 @@ postinst ()
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
     # Sync certificate
-    /var/packages/Mono/target/usr/local/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
+    /volume1/@appstore/mono/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
 
     exit 0
 }
@@ -49,7 +49,7 @@ preupgrade ()
 postupgrade ()
 {
     # Sync certificate
-    /var/packages/Mono/target/usr/local/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
+    /volume1/@appstore/mono/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
 
     exit 0
 }

--- a/spk/mono/src/installer.sh
+++ b/spk/mono/src/installer.sh
@@ -23,7 +23,7 @@ postinst ()
     chown -R ${USER}:root ${SYNOPKG_PKGDEST}
 
     # Sync certificate
-    /volume1/@appstore/mono/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
+    /var/packages/mono/target/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
 
     exit 0
 }
@@ -49,7 +49,7 @@ preupgrade ()
 postupgrade ()
 {
     # Sync certificate
-    /volume1/@appstore/mono/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
+    /var/packages/mono/target/bin/cert-sync /etc/ssl/certs/ca-certificates.crt
 
     exit 0
 }


### PR DESCRIPTION
Based on the feedback from https://github.com/SynoCommunity/spksrc/issues/2808#issuecomment-346402046
Not sure if this is the best practice solution

_Motivation:_ Should fix the certificate store initialization
_Linked issues:_ https://github.com/SynoCommunity/spksrc/issues/2808

### Checklist
- [] Build rule `all-supported` completed successfully
- [] Package upgrade completed successfully
- [] New installation of package completed successfully
